### PR TITLE
fix filter iteration. fixes #3

### DIFF
--- a/src/Data/List/Fast.js
+++ b/src/Data/List/Fast.js
@@ -51,30 +51,18 @@ exports.filter = function(f) {
     if (input === Nil.value) {
       return input;
     } else {
-      var result = new Cons(null, null);
-
+      var result = new Cons(input.value0, Nil.value);
       var output = result;
 
-      while (true) {
+      while (input.value1 !== Nil.value) {
+        input = input.value1;
         var b = f(input.value0);
 
         if (b) {
-          output.value0 = input.value0;
-          output.value1 = new Cons(null, null);
-        }
-
-        if (input.value1 === Nil.value) {
-          break;
-        }
-
-        if (b) {
+          output.value1 = new Cons(input.value0, Nil.value);
           output = output.value1;
         }
-
-        input = input.value1;
       }
-
-      output.value1 = Nil.value;
 
       return result;
     }


### PR DESCRIPTION
In some cases, `filter` would leave a list with a final Cons cell containing a `null` value0. This fix simplifies the iteration and prevents this from happening.